### PR TITLE
Add maintainer onboarding guide

### DIFF
--- a/.github/onboarding.md
+++ b/.github/onboarding.md
@@ -1,0 +1,39 @@
+# Maintainer Onboarding Guide
+
+Welcome aboard, This document will help you get started as a maintainer. Please follow this guide to get started
+
+## ✅ Maintainer Responsibilities
+
+1. **Watch the Repository**
+   - Enable notifications for new issues and pull requests (PRs).
+   - Stay updated with project activity.
+
+2. **Follow Contribution Guidelines**
+   - Adhere to formatting and style rules in `CONTRIBUTING.md`.
+   - Provide constructive feedback on PRs and issues.
+
+3. **Triage Issues**
+   - Label issues appropriately (bug, enhancement, question, etc.).
+   - Request additional details if necessary.
+
+4. **Review and Merge PRs**
+   - Ensure CI checks pass.
+   - Check for compliance with `CONTRIBUTING.md` guidelines.
+   - Check for proper documentation updates.
+
+5. **Suggest Improvements**
+   - Open issues or PRs for tool improvements or workflow enhancements.
+
+6. **Keep the Repository Organized**
+   - Maintain clean categories and keep tools up-to-date.
+
+## 🔹 Onboarding Steps
+
+1. Complete the checklist above.
+2. Confirm access to repository settings and permissions.
+3. Reach out with any questions or suggestions.
+4. Once onboarded, update this document if needed for future maintainers.
+
+Welcome again, and happy contributing! 🚀
+
+---


### PR DESCRIPTION
# 🛠️ Pull Request: Add Maintainer onboarding guide.

- Created `.github/onboarding.md`.
- Covers repo setup, issue triage, PR handling and maintenance tasks.
- Designed for future maintainer reuse.

I was thinking to have a monthly review of outdated tools, broken links etc. 
What do you think?

Let me know if the guide looks right, I'll update accordingly if any changes are required.
@mathewlewallen 
