### PR TITLE
Add PageGuard - free website health scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Site | Category | Description
 [GTMetrix] | `Performance` | Website speed and performance reports.
 [PageSpeed Insights] | `Performance` | Google's tool for analyzing web performance.
 [WebPageTest] | `Performance` | Real browser-based performance testing.
+[PageGuard] | `Performance` | Free all-in-one website health scanner: SEO, accessibility, and performance scores with AI analysis.
 [CodePen] | `Playground` | Frontend design sandbox with live preview.
 [JSBin] | `Playground` | JS testing tool with live code sharing.
 [JSFiddle] | `Playground` | Live HTML/CSS/JS editor with preview.
@@ -221,6 +222,7 @@ Site | Category | Description
 [pagespeed insights]: https://developers.google.com/speed/pagespeed/insights
 [webpagetest]: http://www.webpagetest.org/
 [gtmetrix]: http://gtmetrix.com/
+[pageguard]: https://pageguard.org
 [import.io]: https://www.import.io/
 [webz.io]: https://Webz.io
 [dexi.io]: https://dexi.io/


### PR DESCRIPTION
## What is PageGuard?

[PageGuard](https://pageguard.org) is a free all-in-one website health scanner that covers SEO, accessibility, and performance — with AI-powered analysis. No signup required.

## Why it belongs here

The Performance section currently has GTMetrix, PageSpeed Insights, and WebPageTest. PageGuard extends this by combining SEO + accessibility + performance checks in a single free tool — making it a valuable complement to the existing tools.

## Change

Added PageGuard to the **Performance** section and the link references at the bottom.

```
[PageGuard] | `Performance` | Free all-in-one website health scanner: SEO, accessibility, and performance scores with AI analysis.
```