### PR TITLE
Add: Agency Margin Calculator

### DIFF
--- a/_partials/readme-data.md
+++ b/_partials/readme-data.md
@@ -120,6 +120,7 @@ Site                | Category     | Description
 [Web Monetization] | `Miscellaneous` | A free open web standard service that allows you to send money directly in your browser.
 [Open Source Supporters] | `Miscellaneous` | Companies that offer their tools and services for free to open source projects.
 [ZeroKit.dev] | `DevTools` | 117 free browser-based developer tools including JSON formatter, regex tester, and DNS lookup.
+[Agency Margin Calculator] | `Productivity` | Margin, LTV, and payback calculator for white-label SaaS reseller scenarios. Drop-in iframe embed.
 ---
 
 ## Free with Generous Tier
@@ -271,6 +272,7 @@ Site               | Category     | Description
 [web monetization]: https://github.com/thomasbnt/awesome-web-monetization#readme
 [open source supporters]: https://github.com/zachflower/awesome-open-source-supporters#readme
 [zerokit.dev]: https://zerokit.dev
+[agency margin calculator]: https://sales-label.com/tools/margin-calculator
 
 <!-- Generous Free Tier -->
 [auth0]: https://auth0.com/


### PR DESCRIPTION
Adds Agency Margin Calculator — a free, hosted, embeddable calculator for white-label SaaS reseller margins.

**Tool:** [Agency Margin Calculator](https://sales-label.com/tools/margin-calculator)
**Category:** Productivity
**Pricing tier:** Completely Free (Hosted, No Limits)
**Why it fits:**
- ✅ Completely free, no signup
- ✅ Hosted (no setup required)
- ✅ Drop-in iframe embed: `<iframe src="https://sales-label.com/tools/margin-calculator?embed=true" width="100%" height="900">`
- ✅ Useful for indie agency operators planning reseller pricing

The calculator estimates monthly revenue, profit, gross/net margin, customer LTV, payback period, and annual profit based on inputs like clients, retainer, churn rate, and S&M spend. Open-source MIT implementation also available at https://github.com/Jul010101/agency-margin-calculator.

Edited `_partials/readme-data.md` per contributing.md instructions, added entry at the bottom of Completely Free section table + link reference.