### PR TITLE
Add Mac PPI Calculator & Retina Checker (Design)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Site | Category | Description
 [BitBucket] | `Version Control` | Git solution from Atlassian, integrates with Jira and Trello.
 [GitHub] | `Version Control` | Code hosting platform with collaboration, CI/CD, and issue tracking.
 [GitLab] | `Version Control` | Full DevOps lifecycle tool, Git hosting and pipelines.
+[Mac PPI Calculator & Retina Checker] | `Design` | Calculate a monitor's pixel density and whether it renders Retina-sharp on macOS.
 
 
 ---
@@ -290,6 +291,7 @@ Site | Category | Description
 [freecodecamp]: https://www.freecodecamp.org
 [sourcegraph cody]: https://sourcegraph.com/cody
 [carbon]: https://carbon.now.sh
+[mac ppi calculator & retina checker]: https://retinadesk.com/tools/ppi-calculator/
 [astro]: https://astro.build
 [openui]: https://openui.org
 [fontshare]: https://www.fontshare.com


### PR DESCRIPTION
🎨 Adding one genuinely free, no-signup **Design** tool that designers and front-end folks reach for when speccing screens:

- **[Mac PPI Calculator & Retina Checker](https://retinadesk.com/tools/ppi-calculator/)** — punch in resolution + size and instantly see a display's pixel density and whether it renders Retina-sharp on macOS, with a HiDPI scaling preview. 🔍

✅ Added to **Completely Free (Hosted, No Limits)**, `Design` category, at the bottom of the table
✅ Link reference added · description doesn't start with A/An/The · no trailing punctuation issues

In good company alongside Carbon, Haikei, and Ray.so — hope it earns a spot! 🙌