### PR TITLE
Add SwapFile.io to Image category

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Site | Category | Description
 [Mailersend] | `Email` | 3,000 free emails/month with analytics and templates.
 [Resend] | `Email` | Send up to 3,000 emails/month on the free tier.
 [ImgTools] | `Image` | Free online image tools: compress, resize, crop, convert, watermark, and background removal.
+[SwapFile.io] | `Image` | Privacy-first online image & PDF converter (HEIC, AVIF, WebP, JPG, PNG, BMP, TIFF); files auto-deleted in 1 hour, no Google Analytics.
 [Highlight.io] | `Monitoring` | Session replay, error tracking, and logging in one SDK.
 [Sentry] | `Monitoring` | Catch and triage frontend/backend exceptions.
 [Vercel Analytics] | `Performance` | Track real-user metrics like TTFB, CLS, and LCP.
@@ -336,6 +337,7 @@ Site | Category | Description
 [formbricks]: https://formbricks.com
 [devtools]: https://devtools.davrapps.dev
 [imgtools]: https://imgtools.davrapps.dev
+[swapfile.io]: https://swapfile.io
 
 ---
 


### PR DESCRIPTION
Adds [SwapFile.io](https://swapfile.io) to the `Image` category in `Completely Free (Hosted, No Limits)` — next to ImgTools.

### Why it fits

- **Hosted, free, no daily limits** for anonymous users (matches the section)
- Distinguishes itself from ImgTools (compress/resize/crop/watermark) by focusing on **format conversion** (HEIC, AVIF, WebP, JPG, PNG, BMP, TIFF) and **PDF tools** (PDF → image, PDF merge)
- **Privacy guarantees**: HTTPS upload, files auto-deleted within 1 hour, Plausible analytics only (cookieless, 1 KB), no Google Analytics, no Facebook Pixel
- No required signup for files under 5 MB

### Transparency

- Closed-source for now (single-founder side project, no current self-host option). Considering open-source after Q4 2026 monetization.
- Server-side processing using ImageMagick + Ghostscript on a single VPS.

Live: https://swapfile.io
Privacy policy: https://swapfile.io/en/privacy-policy

Happy to address any feedback. Thanks for maintaining this list.