### PR TITLE
Add: ToolBox

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Site | Category | Description
 [Klotho] | `DevTools` | CLI that converts application code into cloud infrastructure.
 [Responsively App] | `DevTools` | Browser to test websites across multiple viewports simultaneously.
 [Snippet Generator] | `DevTools` | Generate styled code-snippet images for sharing.
+[ToolBox] | `DevTools` | 170+ free browser-based developer tools (JSON formatter, diff checker, regex tester). No signup; client-side.
 [ZeroKit.dev] | `DevTools` | 117 free browser-based developer tools including JSON formatter, regex tester, and DNS lookup.
 [CloudFlare] | `DNS/CDN` | Global CDN, DDoS protection, DNS, and analytics.
 [ClouDNS] | `DNS/CDN` | Managed DNS hosting provider.
@@ -311,6 +312,7 @@ Site | Category | Description
 [web monetization]: https://github.com/thomasbnt/awesome-web-monetization#readme
 [open source supporters]: https://github.com/zachflower/awesome-open-source-supporters#readme
 [zerokit.dev]: https://zerokit.dev
+[toolbox]: https://www.toolbox-kit.com
 
 <!-- Generous Free Tier -->
 [auth0]: https://auth0.com/

--- a/_partials/readme-data.md
+++ b/_partials/readme-data.md
@@ -120,6 +120,7 @@ Site                | Category     | Description
 [Web Monetization] | `Miscellaneous` | A free open web standard service that allows you to send money directly in your browser.
 [Open Source Supporters] | `Miscellaneous` | Companies that offer their tools and services for free to open source projects.
 [ZeroKit.dev] | `DevTools` | 117 free browser-based developer tools including JSON formatter, regex tester, and DNS lookup.
+[ToolBox] | `DevTools` | 170+ free browser-based developer tools (JSON formatter, diff checker, regex tester). No signup; client-side.
 ---
 
 ## Free with Generous Tier
@@ -271,6 +272,7 @@ Site               | Category     | Description
 [web monetization]: https://github.com/thomasbnt/awesome-web-monetization#readme
 [open source supporters]: https://github.com/zachflower/awesome-open-source-supporters#readme
 [zerokit.dev]: https://zerokit.dev
+[toolbox]: https://www.toolbox-kit.com
 
 <!-- Generous Free Tier -->
 [auth0]: https://auth0.com/

--- a/category.md
+++ b/category.md
@@ -178,6 +178,7 @@ Tool | Description | Pricing Tier
 [Klotho] | CLI that converts application code into cloud infrastructure. | Completely Free (Hosted, No Limits)
 [Responsively App] | Browser to test websites across multiple viewports simultaneously. | Completely Free (Hosted, No Limits)
 [Snippet Generator] | Generate styled code-snippet images for sharing. | Completely Free (Hosted, No Limits)
+[ToolBox] | 170+ free browser-based developer tools (JSON formatter, diff checker, regex tester). No signup; client-side. | Completely Free (Hosted, No Limits)
 [ZeroKit.dev] | 117 free browser-based developer tools including JSON formatter, regex tester, and DNS lookup. | Completely Free (Hosted, No Limits)
 [DevTools] | 14 free client-side developer tools: JSON formatter, Base64 encoder, JWT decoder, UUID generator, hash generator, regex tester, and more. | Free with Generous Tier
 [Pinggy] | Instant public URLs & tunnels to localhost; unlimited free bandwidth. | Free with Generous Tier
@@ -578,6 +579,7 @@ Badges are a free easy way to enhance README.md files and attract contributors. 
 [web monetization]: https://github.com/thomasbnt/awesome-web-monetization#readme
 [open source supporters]: https://github.com/zachflower/awesome-open-source-supporters#readme
 [zerokit.dev]: https://zerokit.dev
+[toolbox]: https://www.toolbox-kit.com
 [auth0]: https://auth0.com/
 [vercel analytics]: https://vercel.com/docs/analytics
 [highlight.io]: https://highlight.io


### PR DESCRIPTION
Adds ToolBox to the Completely Free / DevTools section: 170+ free, client-side developer tools (JSON formatter, diff checker, regex tester, hash/UUID generators) with no signup for core tools. Edited `_partials/readme-data.md` and regenerated `README.md` and `category.md` via the build scripts; the row is placed alphabetically within the DevTools group.