### PR TITLE
Add JSONViewerTool (DevTools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Site | Category | Description
 [Turborepo Cache] | `DevOps` | Free on Vercel, speeds up builds across monorepo packages.
 [WinSCP] | `DevOps` | SFTP, FTP, and SCP client for file transfer.
 [XAMPP] | `DevOps` | Local development environment for PHP and MySQL.
+[JSONViewerTool] | `DevTools` | 50+ free client-side JSON tools: viewer, formatter, validator, compare, and JSON↔CSV/YAML/XML converters. No signup, nothing uploaded.
 [Klotho] | `DevTools` | CLI that converts application code into cloud infrastructure.
 [Responsively App] | `DevTools` | Browser to test websites across multiple viewports simultaneously.
 [Snippet Generator] | `DevTools` | Generate styled code-snippet images for sharing.
@@ -336,6 +337,7 @@ Site | Category | Description
 [formbricks]: https://formbricks.com
 [devtools]: https://devtools.davrapps.dev
 [imgtools]: https://imgtools.davrapps.dev
+[jsonviewertool]: https://jsonviewertool.com
 
 ---
 


### PR DESCRIPTION
Adds [JSONViewerTool](https://jsonviewertool.com) under **Completely Free (Hosted, No Limits) › DevTools**, alphabetically before Klotho.

A free, 100% client-side suite of JSON utilities — viewer, formatter, validator, compare/diff, JSON Schema, and converters (JSON↔CSV/YAML/XML/Excel/SQL), plus JWT decoder and Base64/UUID helpers. No signup and nothing is uploaded — everything runs in the browser, no limits. Added the matching reference-link definition too.

Thanks for maintaining the list!