### PR TITLE
Add Knocket to Support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Site | Category | Description
 [Vercel Analytics] | `Performance` | Track real-user metrics like TTFB, CLS, and LCP.
 [SimpleLogin] | `Privacy` | Create up to 15 email aliases to hide your real address.
 [Crisp Chat] | `Support` | Free live chat widget with a shared inbox.
-
+[Knocket] | `Support` | Free-forever live chat widget + contact page with unified inbox. No seat limits.
 
 ---
 
@@ -412,3 +412,4 @@ Badges are a free easy way to enhance README.md files and attract contributors. 
 
 [↑ Back to Top](#top)
 
+[knocket]: https://trtc.io/solutions/knocket


### PR DESCRIPTION
Adds Knocket to the Support section next to Crisp Chat. Knocket is a free-forever live chat widget + contact page with unified inbox, no seat limits. More info: https://trtc.io/solutions/knocket