### PR TITLE
Add Toolio to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Site | Category | Description
 [Mailtolink.me] | `Utilities` | Generate custom mailto: links with pre-filled fields.
 [SmallDev.tools] | `Utilities` | Online formatters, validators, and developer helpers—no signup.
 [Snapdrop] | `Utilities` | Browser-based AirDrop alternative for local file transfers.
+[Toolio] | `Utilities` | 195 browser tools—PDF, image, converters, calculators, dev utilities—most running client-side with no upload.
 [AWS CodeCommit] | `Version Control` | Private Git hosting from Amazon Web Services.
 [Azure Repos] | `Version Control` | Git repos integrated with Azure DevOps.
 [BitBucket] | `Version Control` | Git solution from Atlassian, integrates with Jira and Trello.
@@ -296,6 +297,7 @@ Site | Category | Description
 [mailtolink.me]: https://mailtolink.me
 [responsively app]: https://responsively.appsimultaneously.app
 [snapdrop]: https://snapdrop.net
+[toolio]: https://toolio.pongvn.com
 [runno playground]: https://play.runno.dev
 [turborepo]: https://turbo.build/repo
 [monaspace fonts]: https://monaspace.githubnext.com


### PR DESCRIPTION
Adds [Toolio](https://toolio.pongvn.com) to the `Utilities` category under **Completely Free (Hosted, No Limits)**.

Toolio is a free, no-signup set of 195 browser tools — PDF, image, converters, calculators, and developer utilities. Most of them run client-side, so files never leave the browser. Hosted, no limits, no account.

- Row placed alphabetically within `Utilities` (after Snapdrop), matching the `[Name] | \`Category\` | Description.` format.
- Reference link added to the block at the bottom, alongside the other entries.
- Full disclosure: I'm the maker. Happy to adjust the description or category, or drop it if it isn't a fit.

Thanks for maintaining the list!