### PR TITLE
Add Free Recipe Card Maker to Design section

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Site | Category | Description
 [Monaspace Fonts] | `Design` | Distinctive family of monospaced fonts by GitHub.
 [OpenPeeps] | `Design` | Hand-drawn vector illustration library for UI mock-ups.
 [Ray.so] | `Design` | Create beautiful code screenshots with customizable themes.
+[Free Recipe Card Maker] | `Design` | Create & print printable recipe cards online. No sign-up, no watermark.
 [Astro] | `Development` | Static-site framework that ships zero JS by default.
 [DevDocs] | `Development` | Fast, searchable documentation browser with offline mode for 100-plus languages & APIs.
 [Docker] | `DevOps` | Container platform for building and deploying apps.


### PR DESCRIPTION
## Description
Add [Free Recipe Card Maker](https://free-recipe-card.com/) to the Design section.

This is a completely free online tool for creating printable recipe cards — no sign-up, no watermark, no limits. Users fill in recipe details, pick a template (Classic/Modern/Minimal/Rustic), choose a card color, and download as PDF or PNG.

- **URL**: https://free-recipe-card.com/
- **Category**: Design
- **Pricing**: Completely free (hosted, no limits)
- **Why it fits**: Easy to integrate (just link to the tool), zero-config for end users, unlimited creates
