### PR TITLE
Add: CodeKitHub

### DIFF
--- a/_partials/readme-data.md
+++ b/_partials/readme-data.md
@@ -84,6 +84,7 @@ Site                | Category     | Description
 [Iconshock Free Bundle] | `Design` | Thousands of editable, royalty-free SVG/PNG icon sets.
 [Diagrams.net] | `Design` | Diagramming tool for flowcharts, architecture, org charts, and more.
 [SmallDev.tools] | `Utilities` | Online formatters, validators, and developer helpers—no signup.
+[CodeKitHub]           | `Utilities`   | 47 free browser-based tools: formatters, converters, calculators, and AI prompt libraries—no signup.
 [Klotho] | `DevTools` | CLI that converts application code into cloud infrastructure.
 [OpenAPI.Tools] | `API` | Directory of free tools for designing and testing OpenAPI specs.
 [Kandinsky 3 Playground] | `AI` | Image generator powered by Sberbanks Kandinsky diffusion model.
@@ -271,6 +272,7 @@ Site               | Category     | Description
 [web monetization]: https://github.com/thomasbnt/awesome-web-monetization#readme
 [open source supporters]: https://github.com/zachflower/awesome-open-source-supporters#readme
 [zerokit.dev]: https://zerokit.dev
+[codekithub]: https://codekithub.com/en/
 
 <!-- Generous Free Tier -->
 [auth0]: https://auth0.com/


### PR DESCRIPTION
## Tool Details

Tool Name: CodeKitHub
Link: https://codekithub.com/en/
Pricing Tier: Completely Free (Hosted, No Limits)
Category: Utilities
Short Description: 47 free browser-based tools (formatters, converters, calculators, and AI prompt libraries), no signup required.

## Checklist confirmation

I've read the contribution guidelines, confirmed this tool isn't already listed (and isn't on the Awesome Self-Hosted list), it fits the Utilities category and Completely Free tier, it's actively maintained, and it doesn't duplicate an existing entry.

## Notes

Same spirit as SmallDev.tools and ZeroKit.dev, already listed in this Utilities section: a hosted collection of client-side developer/everyday tools with zero setup, nothing to install or configure. Covers JSON/Base64/URL/case-conversion utilities plus everyday calculators (tip, GPA, percentage) and an AI prompt library.