### PR TITLE
Add: Nutilz CSS Minifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Site | Category | Description
 [Responsively App] | `DevTools` | Browser to test websites across multiple viewports simultaneously.
 [Snippet Generator] | `DevTools` | Generate styled code-snippet images for sharing.
 [ZeroKit.dev] | `DevTools` | 117 free browser-based developer tools including JSON formatter, regex tester, and DNS lookup.
+[Nutilz CSS Minifier] | `DevTools` | Browser-based CSS minifier that strips whitespace and comments — no signup required.
 [CloudFlare] | `DNS/CDN` | Global CDN, DDoS protection, DNS, and analytics.
 [ClouDNS] | `DNS/CDN` | Managed DNS hosting provider.
 [FreeCodeCamp] | `Education` | Full coding curriculum with certifications and projects.
@@ -336,6 +337,7 @@ Site | Category | Description
 [formbricks]: https://formbricks.com
 [devtools]: https://devtools.davrapps.dev
 [imgtools]: https://imgtools.davrapps.dev
+[nutilz css minifier]: https://nutilz.com/css-minifier
 
 ---
 


### PR DESCRIPTION
Adds Nutilz CSS Minifier (https://nutilz.com/css-minifier) to the DevTools category under Completely Free.

- Free, browser-based, no signup required
- Strips whitespace and comments from CSS
- Checked README, no-go-list.md, and category.md — not already listed, category `DevTools` is valid, name/description follow the formatting guide in contributing.md

Follows the contribution checklist in contributing.md.