### PR TITLE
Add: Nutilz File Size Converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Site | Category | Description
 [Mailtolink.me] | `Utilities` | Generate custom mailto: links with pre-filled fields.
 [SmallDev.tools] | `Utilities` | Online formatters, validators, and developer helpers—no signup.
 [Snapdrop] | `Utilities` | Browser-based AirDrop alternative for local file transfers.
+[Nutilz File Size Converter] | `Utilities` | Convert between B, KB, MB, GB, and TB instantly in the browser—no signup, no upload.
 [AWS CodeCommit] | `Version Control` | Private Git hosting from Amazon Web Services.
 [Azure Repos] | `Version Control` | Git repos integrated with Azure DevOps.
 [BitBucket] | `Version Control` | Git solution from Atlassian, integrates with Jira and Trello.
@@ -298,6 +299,7 @@ Site | Category | Description
 [snapdrop]: https://snapdrop.net
 [runno playground]: https://play.runno.dev
 [turborepo]: https://turbo.build/repo
+[nutilz file size converter]: https://nutilz.com/file-size-converter
 [monaspace fonts]: https://monaspace.githubnext.com
 [kde]: https://github.com/francoism90/awesome-kde#readme
 [free programming books]: https://github.com/EbookFoundation/free-programming-books#readme


### PR DESCRIPTION
Adds Nutilz File Size Converter (https://nutilz.com/file-size-converter) to the Utilities section — a free, no-signup, browser-based tool for converting between B, KB, MB, GB, and TB.

Followed the contribution checklist: placed at the bottom of the Utilities table, correct `Category` tag, description avoids generic/forbidden phrasing.