### PR TITLE
Add PDF Mavericks to Completely Free (Utilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Site | Category | Description
 [Tails] | `UI Kit` | Library of modern Tailwind CSS components and templates.
 [Documenso] | `Utilities` | Open-source digital document-signing platform.
 [Mailtolink.me] | `Utilities` | Generate custom mailto: links with pre-filled fields.
+[PDF Mavericks] | `Utilities` | Compress, merge, split, sign and convert PDFs in the browser; files never leave the device.
 [SmallDev.tools] | `Utilities` | Online formatters, validators, and developer helpers—no signup.
 [Snapdrop] | `Utilities` | Browser-based AirDrop alternative for local file transfers.
 [AWS CodeCommit] | `Version Control` | Private Git hosting from Amazon Web Services.
@@ -332,6 +333,7 @@ Site | Category | Description
 [mintlify writer]: https://mintlify.com
 [simplelogin]: https://simplelogin.io
 [pinggy]: https://pinggy.io
+[pdf mavericks]: https://www.pdfmavericks.com/compress
 [stackblitz]: https://stackblitz.com
 [formbricks]: https://formbricks.com
 [devtools]: https://devtools.davrapps.dev


### PR DESCRIPTION
Adds [PDF Mavericks](https://www.pdfmavericks.com/compress) to Completely Free (Hosted, No Limits) under `Utilities`.

It compresses, merges, splits, signs and converts PDFs entirely in the browser — no upload, no account, no server, no page or file-size limits. Processing runs in JavaScript and wasm, so files never leave the device. There is anonymous usage analytics, no per-file tracking.

Placed next to SmallDev.tools and Snapdrop, which are the closest fit in `Utilities` — browser-side tools rather than hosted services. Added the matching link-reference definition alongside the other lowercase defs.

Happy to move it, change the category, or reword the description.
