### PR TITLE
Add U2Tool to Design category — free in-browser tool suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Site | Category | Description
 [Monaspace Fonts] | `Design` | Distinctive family of monospaced fonts by GitHub.
 [OpenPeeps] | `Design` | Hand-drawn vector illustration library for UI mock-ups.
 [Ray.so] | `Design` | Create beautiful code screenshots with customizable themes.
+[U2Tool] | `Design` | Free in-browser suite: chart generators (timeline, gantt, sankey), text converters and validators — no sign-up, data stays on your device.
 [Astro] | `Development` | Static-site framework that ships zero JS by default.
 [DevDocs] | `Development` | Fast, searchable documentation browser with offline mode for 100-plus languages & APIs.
 [Docker] | `DevOps` | Container platform for building and deploying apps.


### PR DESCRIPTION
Adds [U2Tool](https://www.u2tool.com) to the Design category.

- Free, hosted, no limits (fits the Completely Free section)
- No sign-up required; all tools run in the browser
- Includes chart generators (timeline, gantt, sankey, sunburst), text converters, and validators

Description follows the existing table format.