### PR TITLE
Add: Stackiox

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Site | Category | Description
 [Klotho] | `DevTools` | CLI that converts application code into cloud infrastructure.
 [Responsively App] | `DevTools` | Browser to test websites across multiple viewports simultaneously.
 [Snippet Generator] | `DevTools` | Generate styled code-snippet images for sharing.
+[Stackiox] | `DevTools` | Free client-side developer tools: cron expression generator, JWT decoder, timestamp converter, YAML/JSON converter, and SQL formatter. No signup.
 [ZeroKit.dev] | `DevTools` | 117 free browser-based developer tools including JSON formatter, regex tester, and DNS lookup.
 [CloudFlare] | `DNS/CDN` | Global CDN, DDoS protection, DNS, and analytics.
 [ClouDNS] | `DNS/CDN` | Managed DNS hosting provider.
@@ -336,6 +337,7 @@ Site | Category | Description
 [formbricks]: https://formbricks.com
 [devtools]: https://devtools.davrapps.dev
 [imgtools]: https://imgtools.davrapps.dev
+[stackiox]: https://stackiox.com
 
 ---
 


### PR DESCRIPTION
## What is Stackiox?

[Stackiox](https://stackiox.com) is a collection of free, client-side developer tools:

- **Cron Expression Generator** — visual builder with human-readable output and next run times
- **JWT Decoder & Inspector** — decode header/payload, check expiry status
- **Unix Timestamp Converter** — bidirectional conversion with live clock
- **YAML/JSON Converter** — bidirectional with nested structure support
- **SQL Formatter** — supports MySQL, PostgreSQL, SQLite, T-SQL, BigQuery

## Why it fits this list

- Completely free, no signup, no ads, no rate limits
- 100% client-side — nothing leaves the browser
- No account required
- Works offline if cached

Added to the `DevTools` category in the "Completely Free" section, alongside similar entries like ZeroKit.dev and DevTools.