### PR TITLE
Add: DevSEOCraft

### DIFF
--- a/_partials/readme-data.md
+++ b/_partials/readme-data.md
@@ -120,6 +120,7 @@ Site                | Category     | Description
 [Web Monetization] | `Miscellaneous` | A free open web standard service that allows you to send money directly in your browser.
 [Open Source Supporters] | `Miscellaneous` | Companies that offer their tools and services for free to open source projects.
 [ZeroKit.dev] | `DevTools` | 117 free browser-based developer tools including JSON formatter, regex tester, and DNS lookup.
+[DevSEOCraft] | `DevTools` | 100 free browser-based developer and SEO tools — JWT decoder, cron parser, PDF suite, nothing uploaded.
 ---
 
 ## Free with Generous Tier
@@ -271,6 +272,7 @@ Site               | Category     | Description
 [web monetization]: https://github.com/thomasbnt/awesome-web-monetization#readme
 [open source supporters]: https://github.com/zachflower/awesome-open-source-supporters#readme
 [zerokit.dev]: https://zerokit.dev
+[devseocraft]: https://devseocraft.com
 
 <!-- Generous Free Tier -->
 [auth0]: https://auth0.com/


### PR DESCRIPTION
Adds DevSEOCraft (https://devseocraft.com) to the Completely Free / DevTools section.

100 free, browser-based tools for developers and SEOs — JWT decoder, cron parser, UUID generator, PDF suite, CSS generators, schema markup generators, and more. Everything runs client-side; nothing is uploaded or stored, no account or signup required. Same shape of listing as the existing ZeroKit.dev and DevTools entries.

Checklist:
- [x] Tool is not already in the list or `no-go-list.md`
- [x] Completely free, no paid tier gating features
- [x] Category: `DevTools`
- [x] Added at the bottom of the Completely Free table + link reference, per `contributing.md`