### PR TITLE
Add TextUtil to the list of developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Site | Category | Description
 [Klotho] | `DevTools` | CLI that converts application code into cloud infrastructure.
 [Responsively App] | `DevTools` | Browser to test websites across multiple viewports simultaneously.
 [Snippet Generator] | `DevTools` | Generate styled code-snippet images for sharing.
+[TextUtil] | `DevTools` | 50+ free browser-based text and developer tools (JSON/XML/CSS formatters, Base64, hashing, UUID); 100% client-side, nothing uploaded.
 [ZeroKit.dev] | `DevTools` | 117 free browser-based developer tools including JSON formatter, regex tester, and DNS lookup.
 [CloudFlare] | `DNS/CDN` | Global CDN, DDoS protection, DNS, and analytics.
 [ClouDNS] | `DNS/CDN` | Managed DNS hosting provider.
@@ -412,3 +413,5 @@ Badges are a free easy way to enhance README.md files and attract contributors. 
 
 [↑ Back to Top](#top)
 
+
+[TextUtil]: https://www.textutil.com/


### PR DESCRIPTION
## Checklist

✅ Read the contribution guidelines
✅ Not already on the Awesome Free Tools List
✅ Not on Awesome Self-Hosted (not self-hostable)
✅ Fits an existing pricing tier and category (Completely Free → DevTools)
⬜ Provides SDKs / integration docs — it's a standalone in-browser tool suite (like the existing ZeroKit.dev entry), not an SDK
✅ Currently maintained and not deprecated
✅ Adds clear value; does not duplicate an existing entry
⬜ CI parse — the entry format matches existing rows; leaving for CI to confirm

## Tool Details

Tool Name: TextUtil
Link: https://www.textutil.com/
Pricing Tier: Completely Free (Hosted, No Limits)
Category: DevTools
Short Description: 50+ free browser-based text & developer tools (JSON/XML/CSS formatters, Base64, hashing, UUID) that run 100% client-side.

## Why this tool?

A hosted, no-signup suite of 50+ text and developer utilities that all run entirely in the browser — nothing you paste is uploaded. It fits alongside existing DevTools entries like ZeroKit.dev, with a privacy-first, client-side focus. This PR adds the table row plus a matching reference-style link definition. Live and actively developed at https://www.textutil.com/. Thanks for maintaining this list!