### PR TITLE
Add Nutilz — free browser-based developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Site | Category | Description
 [Tails] | `UI Kit` | Library of modern Tailwind CSS components and templates.
 [Documenso] | `Utilities` | Open-source digital document-signing platform.
 [Mailtolink.me] | `Utilities` | Generate custom mailto: links with pre-filled fields.
+[Nutilz] | `Utilities` | 23 free browser-based developer tools: regex tester, JSON formatter, unit converter, and calculators.
 [SmallDev.tools] | `Utilities` | Online formatters, validators, and developer helpers—no signup.
 [Snapdrop] | `Utilities` | Browser-based AirDrop alternative for local file transfers.
 [AWS CodeCommit] | `Version Control` | Private Git hosting from Amazon Web Services.
@@ -193,6 +194,7 @@ Site | Category | Description
 ---
 
 <!-- Completely Free -->
+[nutilz]: https://nutilz.com
 [dependabot]: https://github.com/dependabot
 [codeql]: https://github.com/github/codeql-action
 [socket.dev]: https://socket.dev

--- a/_partials/readme-data.md
+++ b/_partials/readme-data.md
@@ -91,6 +91,7 @@ Site                | Category     | Description
 [Tails] | `UI Kit` | Library of modern Tailwind CSS components and templates.
 [Neobrutalism Components] | `UI Kit` | Brutalist Tailwind component library for landing pages.
 [Documenso] | `Utilities` | Open-source digital document-signing platform.
+[Nutilz] | `Utilities` | 23 free browser-based developer tools: regex tester, JSON formatter, unit converter, and calculators.
 [Public APIs] | `API` | Searchable index of free public APIs with examples.
 [OpenPeeps] | `Design` | Hand-drawn vector illustration library for UI mock-ups.
 [Hoppscotch] | `API` | Open-source API client for REST, GraphQL and WebSocket testing.
@@ -153,6 +154,7 @@ Site               | Category     | Description
 ---
 
 <!-- Completely Free -->
+[nutilz]: https://nutilz.com
 [dependabot]: https://github.com/dependabot
 [codeql]: https://github.com/github/codeql-action
 [socket.dev]: https://socket.dev

--- a/category.md
+++ b/category.md
@@ -370,6 +370,7 @@ Tool | Description | Pricing Tier
 ---- | ----------- | -------------
 [Documenso] | Open-source digital document-signing platform. | Completely Free (Hosted, No Limits)
 [Mailtolink.me] | Generate custom mailto: links with pre-filled fields. | Completely Free (Hosted, No Limits)
+[Nutilz] | 23 free browser-based developer tools: regex tester, JSON formatter, unit converter, and calculators. | Completely Free (Hosted, No Limits)
 [SmallDev.tools] | Online formatters, validators, and developer helpers—no signup. | Completely Free (Hosted, No Limits)
 [Snapdrop] | Browser-based AirDrop alternative for local file transfers. | Completely Free (Hosted, No Limits)
 
@@ -460,6 +461,7 @@ Badges are a free easy way to enhance README.md files and attract contributors. 
 
 
 
+[nutilz]: https://nutilz.com
 [dependabot]: https://github.com/dependabot
 [codeql]: https://github.com/github/codeql-action
 [socket.dev]: https://socket.dev


### PR DESCRIPTION
Nutilz (https://nutilz.com) offers 23 free browser-based developer tools including regex tester, JSON formatter, unit converter, timestamp converter, and calculators. All tools run completely client-side in the browser with no sign-up or tracking required. Fits the Utilities category under completely free tools.